### PR TITLE
Various fixes to make the GPIO API work

### DIFF
--- a/lib/Device/Chip/Adapter/LinuxKernel.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel.pm
@@ -63,19 +63,17 @@ I'll also be working to add "interrupt" support for the GPIO so that you can use
 sub new {
    my $class = shift;
    my %args = @_;
-   my $i2c_bus = delete $args{i2c_bus};
 
-   # TODO not sure what I'll need to take here yet
-   
-   return bless({args => \%args, i2c_bus => $i2c_bus}, $class);
+   my $self = bless({}, $class);
+
+   defined $args{$_} and $self->{$_} = $args{$_} for qw( i2c_bus spi_bus );
+
+   return $self;
 }
 
 sub new_from_description {
    my $class = shift;
-   my %args = @_;
-
-   # TODO what does this do?
-   return bless({}, $class);
+   return $class->new(@_);
 }
 
 

--- a/lib/Device/Chip/Adapter/LinuxKernel/_SPI.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel/_SPI.pm
@@ -3,17 +3,13 @@ package
 
 use strict;
 use warnings;
-use base qw( Device::Chip::Adapter );
+use base qw( Device::Chip::Adapter::LinuxKernel::_base );
 use Carp qw/croak/;
 
 our $VERSION = '0.00007';
 
 require XSLoader;
 XSLoader::load();
-
-use Device::Chip::Adapter::LinuxKernel::_base;
-use base qw( Device::Chip::Adapter::LinuxKernel::_base );
-use Carp qw/croak/;
 
 sub configure {
     my $self = shift;

--- a/lib/Device/Chip/Adapter/LinuxKernel/_SPI.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel/_SPI.pm
@@ -20,7 +20,10 @@ sub configure {
         _spidev_close($self->{spidev});
     }
 
-    $self->{spidev} = Device::Chip::Adapter::LinuxKernel::_SPI::_spidev_open("/dev/".$self->{spi_bus});
+    my $devpath = "/dev/$self->{spi_bus}";
+    ( $self->{spidev} = Device::Chip::Adapter::LinuxKernel::_SPI::_spidev_open($devpath) ) > -1 or
+	croak "Unable to open $devpath - $!";
+
     Device::Chip::Adapter::LinuxKernel::_SPI::_spidev_set_mode($self->{spidev}, $args{mode})
 	if defined $args{mode};
     Device::Chip::Adapter::LinuxKernel::_SPI::_spidev_set_speed($self->{spidev}, $args{max_bitrate})

--- a/lib/Device/Chip/Adapter/LinuxKernel/_base.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel/_base.pm
@@ -3,7 +3,6 @@ package
 
 use strict;
 use warnings;
-use base qw( Device::Chip::Adapter );
 use Carp qw/croak/;
 
 our $VERSION = '0.00007';


### PR DESCRIPTION
 * Added `->meta_gpios`
 * Skip over GPIO pins we're unable to export (because "RPi Zero W" seems not to support gpio29)
 * Bugfix actually reading and writing pin state
 * Set pin direction before reading/writing