### PR TITLE
Add do-nothing 'power' methods to the protocol subclasses

### DIFF
--- a/lib/Device/Chip/Adapter/LinuxKernel.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel.pm
@@ -130,6 +130,11 @@ sub configure {
     return $self;
 }
 
+sub power {
+    # nothing to do; we don't have control over any power pins
+    Future->done;
+}
+
 sub _read_gpio_info {
     my $self = shift;
     my ($gpio) = @_;

--- a/lib/Device/Chip/Adapter/LinuxKernel/_I2C.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel/_I2C.pm
@@ -38,6 +38,11 @@ sub configure {
     Future->done($self);
 }
 
+sub power {
+    # nothing to do; we don't have control over any power pins
+    Future->done;
+}
+
 sub write {
     my $self = shift;
     my ($bytes_out) = @_;

--- a/lib/Device/Chip/Adapter/LinuxKernel/_SPI.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel/_SPI.pm
@@ -41,6 +41,11 @@ sub DESTROY {
     }
 }
 
+sub power {
+    # nothing to do; we don't have control over any power pins
+    Future->done;
+}
+
 sub readwrite {
     my $self = shift;
     my $bytes = shift;


### PR DESCRIPTION
A lot of adapters do have power control, and most example scripts for chip drivers expect to be able to power up the chip on startup. Since the RPi and others mostly can't, it's best just to give them an empty method so at least the script doesn't crash.