### PR TITLE
Three little bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Returns a new instance of a `Device::Chip::Adapter::LinuxKernel`.
 # KNOWN ISSUES
 
 - I2C reading likely doesn't work properly
-- GPIO performance is probably horrendous.  We re-open the /value file in sysfs over and over for every action.  This could be better by storing the filehandles
 
 # PLANS AHEAD
 

--- a/lib/Device/Chip/Adapter/LinuxKernel.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel.pm
@@ -261,7 +261,7 @@ sub _read_gpio_value {
     my $value = <$fh>;
     close($fh);
     
-    return 0+$fh; # make perl get rid of the \n for us
+    return 0+$value; # make perl get rid of the \n for us
 }
 
 # TODO make this do something, also give it an interface
@@ -286,7 +286,7 @@ sub read_gpios {
     my ($self) = shift;
     my ($gpios) = @_;
     
-    Future->done({map {$_ => $self->_read_gpio_value} @$gpios});
+    Future->done({map {$_ => $self->_read_gpio_value($_)} @$gpios});
 }
 
 

--- a/lib/Device/Chip/Adapter/LinuxKernel.pm
+++ b/lib/Device/Chip/Adapter/LinuxKernel.pm
@@ -200,9 +200,10 @@ sub list_gpios {
         # SysFS interface numbers them all from 0 to the end, so we can generate a list of them based off the final one
         my $lastgpiochip_info = $self->_read_gpiochip_info($lastgpiochip);
         
-        my $count = $lastgpiochip_info->{base} + $lastgpiochip_info->{ngpio};
+        my $base = $lastgpiochip_info->{base};
+        my $max  = $lastgpiochip_info->{base} + $lastgpiochip_info->{ngpio} - 1;
         
-        return map {"gpio".$_} 0..$count-1;
+        return map {"gpio".$_} $base..$max;
     } else {
         return ();
     }


### PR DESCRIPTION
 * Fix for `->list_gpios` when the base number is greater than zero (it starts at 512 on my RPi)
 * Fixes to make `->read_gpios` work; previously it did not
 * Cache the `/value` sysfs filehandles so that repeated reads and writes are faster